### PR TITLE
Includedir should start with #. Fixes #3

### DIFF
--- a/templates/sudoers.j2
+++ b/templates/sudoers.j2
@@ -57,6 +57,6 @@
 {%- if sudo_includedir -%}
   {{ "\n" }}# Directory includes{{ "\n" }}
   {%- for item in sudo_includedir -%}
-    includedir {{ item }}{{ "\n" }}
+    #includedir {{ item }}{{ "\n" }}
   {%- endfor %}
 {% endif %}

--- a/templates/sudoers.j2
+++ b/templates/sudoers.j2
@@ -50,7 +50,7 @@
 {%- if sudo_include -%}
   {{ "\n" }}# File includes{{ "\n" }}
   {%- for item in sudo_include -%}
-    include {{ item }}{{ "\n" }}
+    #include {{ item }}{{ "\n" }}
   {%- endfor %}
 {% endif %}
 


### PR DESCRIPTION
the right syntax for includedir is
# includedir some_dir

```
The #includedir directive can be used to create a sudo.d directory that the system package manager can drop sudoers rules into as part of package installation. For example, given:

#includedir /etc/sudoers.d
```
